### PR TITLE
refactor: refactor NewCommit and MakeCommit to work with cometbft

### DIFF
--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -205,7 +205,8 @@ func (s *TestSuite) Commit(h *header.RawHeader) *types.Commit {
 		PartSetHeader: types.PartSetHeader{Total: 1, Hash: tmrand.Bytes(32)},
 	}
 	round := int32(0)
-	comms := make([]types.CommitSig, len(s.vals))
+
+	sigs := make([]tmproto.CommitSig, len(s.vals))
 	for i, val := range s.vals {
 		v := &types.Vote{
 			ValidatorAddress: s.valSet.Validators[i].Address,
@@ -219,10 +220,28 @@ func (s *TestSuite) Commit(h *header.RawHeader) *types.Commit {
 		sgntr, err := val.(types.MockPV).PrivKey.Sign(types.VoteSignBytes(h.ChainID, v.ToProto()))
 		require.Nil(s.t, err)
 		v.Signature = sgntr
-		comms[i] = v.CommitSig()
+		commitSig := v.CommitSig()
+		sigs[i] = tmproto.CommitSig{
+			BlockIdFlag:      tmproto.BlockIDFlag(commitSig.BlockIDFlag),
+			ValidatorAddress: commitSig.ValidatorAddress,
+			Timestamp:        commitSig.Timestamp,
+			Signature:        commitSig.Signature,
+		}
 	}
 
-	return types.NewCommit(h.Height, round, bid, comms)
+	// Create a proto.Commit manually
+	protoCommit := &tmproto.Commit{
+		Height:     h.Height,
+		Round:      round,
+		BlockID:    bid.ToProto(),
+		Signatures: sigs,
+	}
+
+	// Convert to types.Commit
+	commit, err := types.CommitFromProto(protoCommit)
+	require.NoError(s.t, err)
+
+	return commit
 }
 
 func (s *TestSuite) nextProposer() *types.Validator {

--- a/header/headertest/testing.go
+++ b/header/headertest/testing.go
@@ -104,15 +104,21 @@ func (s *TestSuite) genesis() *header.ExtendedHeader {
 }
 
 func MakeCommit(
-	blockID types.BlockID, height int64, round int32,
-	voteSet *types.VoteSet, validators []types.PrivValidator, now time.Time,
+	blockID types.BlockID,
+	height int64,
+	round int32,
+	voteSet *types.VoteSet,
+	validators []types.PrivValidator,
+	now time.Time,
 ) (*types.Commit, error) {
-	// all sign
-	for i := 0; i < len(validators); i++ {
+	commitSigs := make([]tmproto.CommitSig, len(validators))
+
+	for i := range validators {
 		pubKey, err := validators[i].GetPubKey()
 		if err != nil {
 			return nil, fmt.Errorf("can't get pubkey: %w", err)
 		}
+
 		vote := &types.Vote{
 			ValidatorAddress: pubKey.Address(),
 			ValidatorIndex:   int32(i),
@@ -125,11 +131,32 @@ func MakeCommit(
 
 		_, err = signAddVote(validators[i], vote, voteSet)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error signing vote: %w", err)
+		}
+
+		blockIDFlag := tmproto.BlockIDFlagAbsent
+		if !vote.BlockID.IsZero() {
+			blockIDFlag = tmproto.BlockIDFlagCommit
+		} else {
+			blockIDFlag = tmproto.BlockIDFlagNil
+		}
+
+		commitSigs[i] = tmproto.CommitSig{
+			BlockIdFlag:      blockIDFlag,
+			ValidatorAddress: vote.ValidatorAddress,
+			Timestamp:        vote.Timestamp,
+			Signature:        vote.Signature,
 		}
 	}
 
-	return voteSet.MakeCommit(), nil
+	protoCommit := &tmproto.Commit{
+		Height:     height,
+		Round:      round,
+		BlockID:    blockID.ToProto(),
+		Signatures: commitSigs,
+	}
+
+	return types.CommitFromProto(protoCommit)
 }
 
 func signAddVote(privVal types.PrivValidator, vote *types.Vote, voteSet *types.VoteSet) (signed bool, err error) {


### PR DESCRIPTION
Since both `types.NewCommit` and `voteSet.MakeCommit()` have been removed, we need to implement the logic manually.

Note: still not building, will be able test everything properly then.

<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
