### PR TITLE
refactor: update block service client

### DIFF
--- a/api/docgen/examples.go
+++ b/api/docgen/examples.go
@@ -91,7 +91,7 @@ func init() {
 	)
 
 	add(errors.New("error"))
-	add(state.Balance{Amount: sdk.NewInt(42), Denom: "utia"})
+	add(state.Balance{Amount: math.NewInt(42), Denom: "utia"})
 	add(share.EmptyEDS())
 	add(rsmt2d.Row)
 	add(network.Connected)

--- a/api/rpc_test.go
+++ b/api/rpc_test.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"context"
+	"cosmossdk.io/math"
 	"encoding/json"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cristalhq/jwt/v5"
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -78,7 +78,7 @@ func TestRPCCallsUnderlyingNode(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedBalance := &state.Balance{
-		Amount: sdk.NewInt(100),
+		Amount: math.NewInt(100),
 		Denom:  "utia",
 	}
 

--- a/blob/service_test.go
+++ b/blob/service_test.go
@@ -977,7 +977,7 @@ func proveAndVerifyShareCommitments(t *testing.T, blobSize int) {
 			require.NoError(t, actualCommitmentProof.Validate())
 			valid, err := actualCommitmentProof.Verify(
 				dataRoot,
-				appconsts.DefaultSubtreeRootThreshold,
+				appconsts.SubtreeRootThreshold,
 			)
 			require.NoError(t, err)
 			require.True(t, valid)
@@ -987,7 +987,7 @@ func proveAndVerifyShareCommitments(t *testing.T, blobSize int) {
 			require.NoError(t, expectedCommitmentProof.Validate())
 			valid, err = expectedCommitmentProof.Verify(
 				dataRoot,
-				appconsts.DefaultSubtreeRootThreshold,
+				appconsts.SubtreeRootThreshold,
 			)
 			require.NoError(t, err)
 			require.True(t, valid)

--- a/cmd/cel-key/main.go
+++ b/cmd/cel-key/main.go
@@ -25,11 +25,11 @@ var initClientCtx = client.Context{}.
 	WithLegacyAmino(encodingConfig.Amino).
 	WithInput(os.Stdin).
 	WithAccountRetriever(types.AccountRetriever{}).
-	WithBroadcastMode(flags.BroadcastBlock).
+	WithBroadcastMode(flags.BroadcastSync). // TODO: was BroadcastBlock
 	WithHomeDir(app.DefaultNodeHome).
 	WithViper("CELESTIA")
 
-var rootCmd = keys.Commands("~")
+var rootCmd = keys.Commands()
 
 func init() {
 	rootCmd.PersistentFlags().AddFlagSet(DirectoryFlags())

--- a/core/fetcher.go
+++ b/core/fetcher.go
@@ -31,13 +31,13 @@ var (
 )
 
 type BlockFetcher struct {
-	client coregrpc.BlockAPIClient
+	client coregrpc.BlockAPIServiceClient
 }
 
 // NewBlockFetcher returns a new `BlockFetcher`.
 func NewBlockFetcher(conn *grpc.ClientConn) (*BlockFetcher, error) {
 	return &BlockFetcher{
-		client: coregrpc.NewBlockAPIClient(conn),
+		client: coregrpc.NewBlockAPIServiceClient(conn),
 	}, nil
 }
 
@@ -179,7 +179,7 @@ func (f *BlockFetcher) SubscribeNewBlockEvent(ctx context.Context) (chan types.E
 func (f *BlockFetcher) receive(
 	ctx context.Context,
 	signedBlockCh chan types.EventDataSignedBlock,
-	subscription coregrpc.BlockAPI_SubscribeNewHeightsClient,
+	subscription coregrpc.BlockAPIService_SubscribeNewHeightsClient,
 ) error {
 	log.Debug("fetcher: started listening for new blocks")
 	for {
@@ -221,7 +221,7 @@ func (f *BlockFetcher) IsSyncing(ctx context.Context) (bool, error) {
 	return resp.SyncInfo.CatchingUp, nil
 }
 
-func receiveBlockByHeight(streamer coregrpc.BlockAPI_BlockByHeightClient) (
+func receiveBlockByHeight(streamer coregrpc.BlockAPIService_BlockByHeightClient) (
 	*SignedBlock,
 	error,
 ) {
@@ -264,7 +264,7 @@ func receiveBlockByHeight(streamer coregrpc.BlockAPI_BlockByHeightClient) (
 	}, nil
 }
 
-func receiveBlockByHash(streamer coregrpc.BlockAPI_BlockByHashClient) (*types.Block, error) {
+func receiveBlockByHash(streamer coregrpc.BlockAPIService_BlockByHashClient) (*types.Block, error) {
 	parts := make([]*tmproto.Part, 0)
 	isLast := false
 	for !isLast {

--- a/core/listener_no_race_test.go
+++ b/core/listener_no_race_test.go
@@ -48,7 +48,7 @@ func TestListenerWithNonEmptyBlocks(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		accounts := cfg.Genesis.Accounts()
 		require.Greater(t, len(accounts), 0)
-		_, err := cctx.FillBlock(16, accounts[0].Name, flags.BroadcastBlock)
+		_, err := cctx.FillBlock(16, accounts[0].Name, flags.BroadcastSync) // TODO: this was BroadcastBlock, expecting failures
 		require.NoError(t, err)
 		msg, err := sub.Next(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Updating to use new types. `make install` is passing, tests are still failing due to dependency on removed types from celestia-app

<!--
Thank you for submitting a pull request!

Please make sure you have reviewed our contributors guide before submitting your
first PR.

Please ensure you've addressed or included references to any related issues.

Tips:
- Use keywords like "closes" or "fixes" followed by an issue number to automatically close related issues when the PR is merged (e.g., "closes #123" or "fixes #123").
- Describe the changes made in the PR.
- Ensure the PR has one of the required tags (kind:fix, kind:misc, kind:break!, kind:refactor, kind:feat, kind:deps, kind:docs, kind:ci, kind:chore, kind:testing)

-->
